### PR TITLE
feat: User 회원가입 (이메일 중복검사 로직 추가), 로그인, global error(이메일 중복시 예외처리) 추가 - (아직 다 못했습니다)

### DIFF
--- a/src/main/java/com/est/jobshin/global/error/ErrorCode.java
+++ b/src/main/java/com/est/jobshin/global/error/ErrorCode.java
@@ -59,6 +59,9 @@ public enum ErrorCode {
 	// @RequestBody 및 @RequestParam, @PathVariable 값이 유효하지 않음
 	NOT_VALID_HEADER_ERROR(404, "G012", "Header에 데이터가 존재하지 않는 경우 "),
 
+	// 회원 가입 시 중복된 이메일이 있는 경우
+	EMAIL_ALREADY_EXISTS(409, "C001", "Email already exists"),
+
 	// 서버가 처리 할 방법을 모르는 경우 발생
 	INTERNAL_SERVER_ERROR(500, "G999", "Internal Server Error Exception"),
 

--- a/src/main/java/com/est/jobshin/global/error/GlobalExceptionHandler.java
+++ b/src/main/java/com/est/jobshin/global/error/GlobalExceptionHandler.java
@@ -1,6 +1,7 @@
 package com.est.jobshin.global.error;
 
 import com.est.jobshin.global.common.ErrorResponse;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -13,6 +14,11 @@ public class GlobalExceptionHandler {
     public ResponseEntity<ErrorResponse> handleMethodArgumentNotValidException(MethodArgumentNotValidException e) {
         ErrorResponse errorResponse = ErrorResponse.of(ErrorCode.NOT_VALID_ERROR, e.getBindingResult());
         return ResponseEntity.badRequest().body(errorResponse);
+    }
+    @ExceptionHandler(IllegalArgumentException.class)
+    public ResponseEntity<ErrorResponse> handleIllegalArgumentException(IllegalArgumentException e) {
+        ErrorResponse errorResponse = ErrorResponse.of(ErrorCode.EMAIL_ALREADY_EXISTS, e.getMessage());
+        return ResponseEntity.status(HttpStatus.CONFLICT).body(errorResponse);
     }
 
 }


### PR DESCRIPTION
## 💡 이슈
resolve #20 

## 🤩 개요
User 회원가입, 로그인 로직 작성및 관련 예외처리 추가

## 🧑‍💻 작업 사항
- 회원가입 (이메일 중복검사 로직 추가)
- global error(409에러) 추가
  - 에러코드(Enum)
    ```java
    // 회원 가입 시 중복된 이메일이 있는 경우
    EMAIL_ALREADY_EXISTS(409, "C001", "Email already exists"),
    ```
  - GlobalExceptionHandler 추가 코드
    ```java
    @ExceptionHandler(IllegalArgumentException.class)
    public ResponseEntity<ErrorResponse> handleIllegalArgumentException(IllegalArgumentException e) {
        ErrorResponse errorResponse = ErrorResponse.of(ErrorCode.EMAIL_ALREADY_EXISTS, e.getMessage());
        return ResponseEntity.status(HttpStatus.CONFLICT).body(errorResponse);
    }
    ```

## 📖 참고 사항
- 중복된 이메일로 회원가입 요청 시 에러 코드
  <img width="424" alt="image" src="https://github.com/user-attachments/assets/8d1da934-8d0c-4c5a-a2f7-8f2dcc1b476d">

## ✅ Check List
- [ ] 코드가 정상적으로 컴파일되나요?
- [ ] 테스트 코드를 통과했나요?
- [ ] merge할 브랜치의 위치를 확인했나요?
- [ ] Label을 지정했나요?
