### PR TITLE
Refactor: Refactor: 메세지 프롬프트 및 AlanService 리펙토링

### DIFF
--- a/src/main/java/com/est/jobshin/infra/alan/AlanService.java
+++ b/src/main/java/com/est/jobshin/infra/alan/AlanService.java
@@ -1,5 +1,6 @@
 package com.est.jobshin.infra.alan;
 
+import com.est.jobshin.domain.interview.domain.Interview;
 import com.est.jobshin.domain.interviewDetail.domain.InterviewDetail;
 import com.est.jobshin.domain.user.domain.User;
 import com.est.jobshin.domain.user.util.Language;
@@ -25,12 +26,23 @@ public class AlanService {
 	private String clientId;
 
 	public String callAlan() {
-		return callApi(defaultUrl, clientId, "test");
+		return callApi(defaultUrl, clientId);
 	}
 
 
-	private String callApi(String apiUrl, String clientId, String level) {
-		String content = String.format(PromptMessage.QUESTION_PROMPT, level);
+//	private String callApi(String apiUrl, String clientId, String level) {
+//		String content = String.format(PromptMessage.QUESTION_PROMPT, level);
+//		String requestUrl = String.format("%s?content=%s&client_id=%s", apiUrl, content, clientId);
+//		log.info("Calling API: {}", requestUrl);
+//		String response = restTemplate.getForObject(requestUrl, String.class);
+//		log.info("API response received");
+//		log.info("Response: {}", response);
+//		return response;
+//	}
+
+	private String callApi(String apiUrl, String clientId) {
+		String message = PromptMessage.QUESTION_PROMPT + "전체 레벨(구성 레벨: LV1, LV2, LV3) 중" + "LV1" + "사용 언어: JAVA";
+		String content = String.format(message);
 		String requestUrl = String.format("%s?content=%s&client_id=%s", apiUrl, content, clientId);
 		log.info("Calling API: {}", requestUrl);
 		String response = restTemplate.getForObject(requestUrl, String.class);
@@ -40,12 +52,13 @@ public class AlanService {
 	}
 
 	// 실전 모드 문제
-	private String callApiRealMode(String apiUrl, String clientId, String level, User user) {
-		String setUpMessage = user.getId() + "전체 레벨(구성 레벨: LV1, LV2, LV3) 중" + user.getLevel() + "사용 언어: " + user.getLanguage();
+	private String callApiRealMode(String apiUrl, String clientId, Interview interview) {
+		String setUpMessage
+				= "전체 레벨(구성 레벨: LV1, LV2, LV3) 중" + interview.getUser().getLevel() + "사용 언어: " + interview.getUser().getLanguage();
 
 		String questionMessage = PromptMessage.QUESTION_PROMPT + setUpMessage;
 
-		String content = String.format(questionMessage, level);
+		String content = String.format(questionMessage);
 		String requestUrl = String.format("%s?content=%s&client_id=%s", apiUrl, content, clientId);
 		log.info("Calling API: {}", requestUrl);
 		String response = restTemplate.getForObject(requestUrl, String.class);
@@ -55,23 +68,29 @@ public class AlanService {
 	}
 
 	// 연습 모드 문제
-	private String callApiPracticeMode(String apiUrl, String ClientId, String level, User user){
-		String setUpMessage = user.getId() + "전체 레벨(구성 레벨: LV1, LV2, LV3) 중" + user.getLevel() + "사용언어: " + user.getLanguage();
+	private String callApiPracticeMode(String apiUrl, String ClientId, User user, InterviewDetail interviewDetail){
+		String setUpMessage = user.getId() + "전체 레벨(구성 레벨: LV1, LV2, LV3) 중" + user.getLevel() + "사용언어: " + user.getLanguage() + "선택한 카테고리: " + interviewDetail.getCategory();
 
-		String questionMessage = "";
+		String questionMessage = "3가지 카테고리(CS(컴퓨터 과학 기초), 프로그래밍 언어 및 도구, 알고리즘) 중 선택한 카테고리 내에서만"
+				+ PromptMessage.QUESTION_PROMPT + setUpMessage;
 
-//		if (InterviewDetail.Category.CS) {
-//			questionMessage =
-//					PromptMessage.QUESTION_PRACTICE_CS_PROMPT + setUpMessage;
-//		} else if(InterviewDetail.Category.LANGUAGE){
-//			questionMessage =
-//					PromptMessage.QUESTION_PRACTICE_LANGUAGE_PROMPT + setUpMessage;
-//		} else if(InterviewDetail.Category.ALGORITHM) {
-//			questionMessage =
-//					PromptMessage.QUESTION_PRACTICE_ALGORITHM_PROMPT + setUpMessage;
-//		}
+		String content = String.format(questionMessage);
+		String requestUrl = String.format("%s?content=%s&client_id=%s", apiUrl, content, clientId);
+		log.info("Calling API: {}", requestUrl);
 
-		String content = String.format(questionMessage, level);
+		String response = restTemplate.getForObject(requestUrl, String.class);
+		log.info("API response received");
+		log.info("Response: {}", response);
+
+		return response;
+	}
+
+	// 모법 답안, 피드백
+	private String callApiAnswer(String apiUrl, String ClientId, User user, InterviewDetail interviewDetail) {
+
+		String message = PromptMessage.ANSWER_PROMPT + PromptMessage.FEEDBACK_PROMPT;
+
+		String content = String.format(message);
 		String requestUrl = String.format("%s?content=%s&client_id=%s", apiUrl, content, clientId);
 		log.info("Calling API: {}", requestUrl);
 

--- a/src/main/java/com/est/jobshin/infra/alan/PromptMessage.java
+++ b/src/main/java/com/est/jobshin/infra/alan/PromptMessage.java
@@ -4,15 +4,9 @@ public class PromptMessage {
 
 	public static final String DEFAULT_PROMPT = "자바 백엔드 개발자 취업 준비에 필요한 기술면접 질문을 5개 뽑아줘";
 
-	// 실전모드 문제 생성 메세지
-	public static final String QUESTION_PROMPT
-			= "백엔드 개발자 취업 준비에 필요한 기술면접 질문을 5개 뽑아두고 하나씩 출력해줘. 매 실행마다 다양한 문제들을 출력해주고 문제 레벨은 총 3단계 중 해당 유저의 레벨에 맞춰 뽑아줘. 질문만 출력해주면 돼";
-
-	// 연습모드 문제 생성 메세지
-	public static final String QUESTION_PRACTICE_CS_PROMPT = "백엔드 개발자로서 준비해야 하는 CS(컴퓨터 과학 기초)에 대한 면접 질문을 5개 뽑아주고 하나씩 출력해줘. 질문만 뽑아주면 돼";
-	public static final String QUESTION_PRACTICE_LANGUAGE_PROMPT = "백엔드 개발자 취업 준비에 필요한 프로그래밍 언어 및 도구와 관련한 기술면접 질문을 5개 뽑아줘. 질문 5개 중 하나씩, 매 실행마다 다양한 문제들을 출력해주고 문제 레벨은 총 3단계 중 해당 유저의 레벨에 맞춰 뽑아줘.";
-	public static final String QUESTION_PRACTICE_ALGORITHM_PROMPT = "백엔드 개발자 취업 준비에 필요한 프로그래밍 언어 파이썬과 관련한 기술면접 질문을 5개 뽑아줘. 질문 5개 중 하나씩, 매 실행마다 다양한 문제들을 출력해주고 문제 레벨은 총 3단계 중 해당 유저의 레벨에 맞춰 뽑아줘.";
-
+// 문제 생성 메세지
+	public static final String QUESTION_PROMPT =
+			"백엔드 개발자 취업 준비에 필요한 기술면접 질문을 5개 뽑아두고 \"한 문제씩만\" 출력해줘. 매 실행마다 다양한 문제들을 출력해주고 문제 레벨은 총 3단계 중 해당 유저의 레벨에 맞춰 뽑아줘. 질문만 출력해주면 돼";
 
 	public static final String ANSWER_PROMPT = "너가 냈던 기술면접 질문 5개에 대한 모범 답안만 알려줘";
 	public static final String FEEDBACK_PROMPT = "사용자로부터 받은 답변을 보고 면접관의 입장에서 어떤지 100점 만점에 몇 점인지 평가와 피드백 해줘. 다른 문장 출력할 필요 없어.";


### PR DESCRIPTION
## 💡 이슈
resolve #35 

## 🤩 개요
- 프롬프트 수정
- AlanService 수정

## 🧑‍💻 작업 사항
프롬프트 메세지 수정
AlanService의 callApiRealMode 메서드 수정
AlanService의 callApiPracticeMode 메서드 수정

## 📖 참고 사항
![image](https://github.com/user-attachments/assets/b81c5696-2496-4eff-9276-1b5d868e47ca)
프롬프트를 사진과 같이 작성하여 미리 5문제 정하고 1문제 씩 나오게 하였는데, 5문제 한꺼번에 생성시키려고 하면 한 문제씩만 지우시면 됩니다.

![image](https://github.com/user-attachments/assets/46e50ef3-16e5-464a-9e5b-c0357703df70)
면접 질문 생성할 때에는 User에 바로 접근하도록 했는데, Interviews의 유저로 접근하도록 하였습니다.
연습 모드는 "선택한 카테고리: " + interviewDetail.getCategory(); 추가

## ✅ Check List
- [ ] 코드가 정상적으로 컴파일되나요?
- [ ] 테스트 코드를 통과했나요?
- [ ] merge할 브랜치의 위치를 확인했나요?
- [ ] Label을 지정했나요?
