### PR TITLE
Feat: 질문 받아와서 db에 저장, 클라이언트에게 질문 하나씩 전송

### DIFF
--- a/src/main/java/com/est/jobshin/domain/interview/controller/InterviewController.java
+++ b/src/main/java/com/est/jobshin/domain/interview/controller/InterviewController.java
@@ -4,6 +4,7 @@ import com.est.jobshin.domain.interview.domain.Interview;
 import com.est.jobshin.domain.interview.dto.InterviewDto;
 import com.est.jobshin.domain.interview.service.InterviewService;
 import com.est.jobshin.infra.alan.AlanService;
+import jakarta.servlet.http.HttpSession;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -22,10 +23,25 @@ public class InterviewController {
 
         return result;
     }
+//    세션 테스트용 임시 주석처리
+//    @PostMapping
+//    public ResponseEntity<InterviewDto> createInterview(@RequestBody InterviewDto interviewDto, HttpSession session) {
+//        Interview interview = interviewService.createInterview(interviewDto, session);
+//        return ResponseEntity.ok(InterviewDto.fromInterview(interview));
+//    }
 
-    @PostMapping
-    public ResponseEntity<Interview> createInterview(@RequestBody InterviewDto interviewDto) {
-        return ResponseEntity.ok(interviewService.createInterview(interviewDto));
+    //세션 테스트용
+    @GetMapping
+    public ResponseEntity<InterviewDto> createInterview(HttpSession session) {
+        InterviewDto interviewDto = new InterviewDto();
+        Interview interview = interviewService.createInterview(interviewDto, session);
+        return ResponseEntity.ok(InterviewDto.fromInterview(interview));
+    }
+
+    @GetMapping("/next")
+    public ResponseEntity<String> next(HttpSession session) {
+        String question = interviewService.getNextQuestion2(session);
+        return ResponseEntity.ok(question);
     }
 
 //    @GetMapping
@@ -44,4 +60,6 @@ public class InterviewController {
         interviewService.deleteInterviewsById(interviewId);
         return ResponseEntity.noContent().build();
     }
+
+
 }

--- a/src/main/java/com/est/jobshin/domain/interview/domain/Interview.java
+++ b/src/main/java/com/est/jobshin/domain/interview/domain/Interview.java
@@ -2,7 +2,9 @@ package com.est.jobshin.domain.interview.domain;
 
 import com.est.jobshin.domain.interviewDetail.domain.InterviewDetail;
 
+import com.est.jobshin.domain.interviewDetail.util.Mode;
 import com.est.jobshin.domain.user.domain.User;
+import com.fasterxml.jackson.annotation.JsonManagedReference;
 import jakarta.persistence.*;
 
 import jakarta.validation.constraints.NotNull;
@@ -23,16 +25,20 @@ public class Interview {
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;
 
-	@NotNull
+//	@NotNull
 	private String title;
 
-	@NotNull
+//	@NotNull
+	private Mode mode;
+
+//	@NotNull
 	private LocalDateTime createAt;
 
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "user_id")
 	private User user;
 
+//	@JsonManagedReference
 	@OneToMany(mappedBy = "interview", cascade = CascadeType.ALL, orphanRemoval = true)
 	private List<InterviewDetail> interviewDetails = new ArrayList<>();
 

--- a/src/main/java/com/est/jobshin/domain/interview/dto/InterviewDto.java
+++ b/src/main/java/com/est/jobshin/domain/interview/dto/InterviewDto.java
@@ -3,7 +3,9 @@ package com.est.jobshin.domain.interview.dto;
 import com.est.jobshin.domain.interview.domain.Interview;
 import com.est.jobshin.domain.interviewDetail.domain.InterviewDetail;
 import com.est.jobshin.domain.interviewDetail.dto.InterviewDetailDto;
+import com.est.jobshin.domain.interviewDetail.dto.InterviewDetailDto2;
 import com.est.jobshin.domain.interviewDetail.dto.InterviewQuestion;
+import com.est.jobshin.domain.interviewDetail.util.Mode;
 import com.est.jobshin.domain.user.dto.UserDto;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import lombok.AllArgsConstructor;
@@ -14,6 +16,7 @@ import lombok.NoArgsConstructor;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Data
 @AllArgsConstructor
@@ -26,16 +29,23 @@ public class InterviewDto {
 
     private UserDto user;
 
-    private List<InterviewQuestion> interviewDetails;
+    private Mode mode;
+
+    private List<InterviewDetailDto2> interviewDetailDto2;
 
     public static InterviewDto fromInterview(Interview interview) {
-        InterviewDto interviewDto;
-        interviewDto = InterviewDto.builder()
+        List<InterviewDetailDto2> interviewDetailDto2 = new ArrayList<>();
+        if(interview.getInterviewDetails() != null) {
+            interviewDetailDto2 = interview.getInterviewDetails().stream()
+                    .map(InterviewDetailDto2::from)
+                    .toList();
+        }
+        return InterviewDto.builder()
                 .title(interview.getTitle())
                 .createAt(interview.getCreateAt())
+                .mode(interview.getMode())
+                .interviewDetailDto2(interviewDetailDto2)
                 .build();
-        interviewDto.setInterviewDetails(new ArrayList<>());
-        return interviewDto;
     }
 
     public Interview toInterview() {

--- a/src/main/java/com/est/jobshin/domain/interview/dto/QuestionMessage.java
+++ b/src/main/java/com/est/jobshin/domain/interview/dto/QuestionMessage.java
@@ -1,0 +1,13 @@
+package com.est.jobshin.domain.interview.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+import java.io.Serializable;
+
+@Data
+@AllArgsConstructor
+public class QuestionMessage implements Serializable {
+    private Long questionId;
+    private String question;
+}

--- a/src/main/java/com/est/jobshin/domain/interview/service/InterviewService.java
+++ b/src/main/java/com/est/jobshin/domain/interview/service/InterviewService.java
@@ -3,11 +3,15 @@ package com.est.jobshin.domain.interview.service;
 import com.est.jobshin.domain.interview.domain.Interview;
 import com.est.jobshin.domain.interview.dto.InterviewDto;
 import com.est.jobshin.domain.interview.repository.InterviewRepository;
+import com.est.jobshin.domain.interviewDetail.domain.InterviewDetail;
+import com.est.jobshin.domain.interviewDetail.dto.InterviewQuestion;
+import com.est.jobshin.domain.interviewDetail.service.InterviewDetailService;
 import com.est.jobshin.domain.user.domain.User;
 import com.est.jobshin.domain.user.dto.UserResponse;
 import com.est.jobshin.domain.user.repository.UserRepository;
 import com.est.jobshin.domain.user.service.UserService;
 import com.est.jobshin.infra.alan.AlanService;
+import jakarta.servlet.http.HttpSession;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.core.Authentication;
@@ -17,17 +21,19 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
 import java.util.NoSuchElementException;
 
 @Service
-@Transactional
 @RequiredArgsConstructor
 public class InterviewService {
     private final InterviewRepository interviewRepository;
-    private final UserRepository userRepository;
-    private final AlanService alanService;
+    private final InterviewDetailService interviewDetailService;
+    private final MessageQueueService messageQueueService;
+//    private Iterator<InterviewDetail> interviewDetailIterator;
 
-    @Transactional(readOnly = true)
+    @Transactional
     public InterviewDto getInterviewById(Long id) {
         return interviewRepository
                 .findById(id)
@@ -35,24 +41,50 @@ public class InterviewService {
                 .orElseThrow(() -> new IllegalArgumentException("Interview not found"));
     }
 
-//        @Transactional(readOnly = true)
-//        public List<InterviewsDto> getAllInterviews() {
-//            return INTERVIEWS_REPOSITORY.findAll()
-//                    .stream().map(InterviewsDto::fromInterviews)
-//                    .collect(Collectors.toList());
-//        }
-
-    public Interview createInterview(InterviewDto interviewDto) {
-//        Interview interview = interviewDto.toInterview();
-//        interview.setInterviewDetails(new ArrayList<>());
-//        interview.setCreateAt(LocalDateTime.now());
-//        Interview savedInterview = interviewRepository.save(interview);
-
-//        User user = getCurrentUser();
+    @Transactional
+    public Interview createInterview(InterviewDto interviewDto, HttpSession session) {
         Interview interview = Interview.createInterview(
                 interviewDto.getTitle(), LocalDateTime.now());
 
-        return interviewRepository.save(interview);
+        Interview createdInterview = interviewRepository.save(interview);
+
+        interviewDetailService.createInterviewDetail(interview);
+
+//        interviewDetailIterator = interview.getInterviewDetails().iterator();
+
+        //메시지큐에 넣기
+//        for(InterviewDetail interviewDetail : interview.getInterviewDetails()) {
+//            messageQueueService.enqueueQuestion(interviewDetail.getId(), interviewDetail.getQuestion());
+//        }
+//        System.out.println();
+        session.setAttribute("questions", new ArrayList<>(interview.getInterviewDetails()));
+        session.setAttribute("currentIndex", 0);
+
+        return createdInterview;
+    }
+
+    public String getNextQuestion2(HttpSession session) {
+        List<InterviewDetail> questions = (List<InterviewDetail>) session.getAttribute("questions");
+        Integer currentIndex = (Integer) session.getAttribute("currentIndex");
+
+        if (questions == null || currentIndex == null || currentIndex >= questions.size()) {
+            return "No more questions";
+        }
+
+        InterviewDetail question = questions.get(currentIndex);
+        session.setAttribute("currentIndex", currentIndex + 1);
+
+        return question.getQuestion();
+    }
+
+    public String getNextQuestion(Long interviewId) {
+        return messageQueueService.dequeueQuestion(interviewId);
+    }
+
+    public void submitAnswer(Long interviewDetailsId, String answer) {
+        InterviewDetail interviewDetail = interviewDetailService.getInterviewDetailById(interviewDetailsId);
+        interviewDetail.setAnswer(answer);
+        //저장
     }
 
     public void deleteInterviewsById(Long id) {

--- a/src/main/java/com/est/jobshin/domain/interview/service/MessageQueueService.java
+++ b/src/main/java/com/est/jobshin/domain/interview/service/MessageQueueService.java
@@ -1,0 +1,23 @@
+package com.est.jobshin.domain.interview.service;
+
+import com.est.jobshin.domain.interview.dto.QuestionMessage;
+import lombok.RequiredArgsConstructor;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class MessageQueueService {
+    private final RabbitTemplate rabbitTemplate;
+
+    public void enqueueQuestion(Long interviewDetailsId, String question) {
+        String queueName = "interview." + interviewDetailsId;
+        rabbitTemplate.convertAndSend(queueName, new QuestionMessage(interviewDetailsId, question));
+    }
+
+    public String dequeueQuestion(Long interviewDetailsId) {
+        String queueName = "interview." + interviewDetailsId;
+        QuestionMessage questionMessage = (QuestionMessage) rabbitTemplate.receiveAndConvert(queueName);
+        return questionMessage != null ? questionMessage.getQuestion() : null;
+    }
+}

--- a/src/main/java/com/est/jobshin/domain/interviewDetail/controller/InterviewDetailController.java
+++ b/src/main/java/com/est/jobshin/domain/interviewDetail/controller/InterviewDetailController.java
@@ -14,21 +14,21 @@ import java.util.List;
 @RequestMapping("/api/mock-interviews/detail")
 @RequiredArgsConstructor
 public class InterviewDetailController {
-    private final InterviewDetailService interviewDetailService;
-
-    @PostMapping("/{interviewId}")
-    public ResponseEntity<InterviewQuestion> createQuestion(@PathVariable("interviewId") Long interviewId, @RequestBody InterviewQuestion interviewQuestion) {
-        InterviewQuestion createdQuestion = interviewDetailService.createInterviewDetail(interviewQuestion, interviewId);
-        return ResponseEntity.ok(createdQuestion);
-    }
-
-    @GetMapping("/question/{interviewId}/{detailId}")
-    public ResponseEntity<InterviewQuestion> getInterviewDetailById(@PathVariable("interviewId") Long interviewId,@PathVariable("detailId") Long detailId) {
-        return ResponseEntity.ok(interviewDetailService.getInterviewDetailById(detailId));
-    }
-
-    @GetMapping("question/{interviewId}")
-    public ResponseEntity<List<InterviewQuestion>> getInterviewDetailByInterviewId(@PathVariable("interviewId") Long interviewId) {
-        return ResponseEntity.ok(interviewDetailService.getInterviewDetailByInterviewId(interviewId));
-    }
+//    private final InterviewDetailService interviewDetailService;
+//
+//    @PostMapping("/{interviewId}")
+//    public ResponseEntity<InterviewQuestion> createQuestion(@PathVariable("interviewId") Long interviewId, @RequestBody InterviewQuestion interviewQuestion) {
+//        InterviewQuestion createdQuestion = interviewDetailService.createInterviewDetail(interviewQuestion, interviewId);
+//        return ResponseEntity.ok(createdQuestion);
+//    }
+//
+//    @GetMapping("/question/{interviewId}/{detailId}")
+//    public ResponseEntity<InterviewQuestion> getInterviewDetailById(@PathVariable("interviewId") Long interviewId,@PathVariable("detailId") Long detailId) {
+//        return ResponseEntity.ok(interviewDetailService.getInterviewDetailById(detailId));
+//    }
+//
+//    @GetMapping("question/{interviewId}")
+//    public ResponseEntity<List<InterviewQuestion>> getInterviewDetailByInterviewId(@PathVariable("interviewId") Long interviewId) {
+//        return ResponseEntity.ok(interviewDetailService.getInterviewDetailByInterviewId(interviewId));
+//    }
 }

--- a/src/main/java/com/est/jobshin/domain/interviewDetail/domain/InterviewDetail.java
+++ b/src/main/java/com/est/jobshin/domain/interviewDetail/domain/InterviewDetail.java
@@ -51,11 +51,12 @@ public class InterviewDetail {
 
     private LocalDateTime createdAt;
 
+//    @JsonBackReference
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "interview_id")
     private Interview interview;
 
-    private InterviewDetail(String question, Category category, Mode mode, String exampleAnswer, LocalDateTime createdAt) {
+    private InterviewDetail(String question, Category category, Mode mode, LocalDateTime createdAt) {
         this.question = question;
         this.category = category;
         this.mode = mode;
@@ -63,7 +64,7 @@ public class InterviewDetail {
         this.createdAt = createdAt;
     }
 
-    public static InterviewDetail createInterviewDetail(String question, Category category, Mode mode, String exampleAnswer, LocalDateTime createdAt) {
-        return new InterviewDetail(question, category, mode, exampleAnswer, createdAt);
+    public static InterviewDetail createInterviewDetail(String question, Category category, Mode mode, LocalDateTime createdAt) {
+        return new InterviewDetail(question, category, mode, createdAt);
     }
 }

--- a/src/main/java/com/est/jobshin/domain/interviewDetail/dto/InterviewDetailDto2.java
+++ b/src/main/java/com/est/jobshin/domain/interviewDetail/dto/InterviewDetailDto2.java
@@ -1,0 +1,25 @@
+package com.est.jobshin.domain.interviewDetail.dto;
+
+import com.est.jobshin.domain.interviewDetail.domain.InterviewDetail;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class InterviewDetailDto2 {
+    private Long id;
+    private String question;
+    private String answer;
+
+    public static InterviewDetailDto2 from(InterviewDetail interviewDetail) {
+        return InterviewDetailDto2.builder()
+                .id(interviewDetail.getId())
+                .question(interviewDetail.getQuestion())
+                .answer(interviewDetail.getAnswer())
+                .build();
+    }
+}

--- a/src/main/java/com/est/jobshin/domain/interviewDetail/dto/InterviewQuestion.java
+++ b/src/main/java/com/est/jobshin/domain/interviewDetail/dto/InterviewQuestion.java
@@ -13,11 +13,9 @@ import lombok.NoArgsConstructor;
 import java.io.Serializable;
 import java.time.LocalDateTime;
 
-///** DTO for {@link com.est.jobshin.domain.interviewDetail.domain.InterviewDetail} */
 @Data
 @Builder
 public class InterviewQuestion implements Serializable {
-
     private Long id;
 
     private Long interviewId;

--- a/src/main/java/com/est/jobshin/infra/alan/PromptMessage.java
+++ b/src/main/java/com/est/jobshin/infra/alan/PromptMessage.java
@@ -5,8 +5,11 @@ public class PromptMessage {
 	public static final String DEFAULT_PROMPT = "자바 백엔드 개발자 취업 준비에 필요한 기술면접 질문을 5개 뽑아줘";
 
 // 문제 생성 메세지
+//	public static final String QUESTION_PROMPT =
+//			"백엔드 개발자 취업 준비에 필요한 기술면접 질문을 5개 뽑아두고 \"한 문제씩만\" 출력해줘. 매 실행마다 다양한 문제들을 출력해주고 문제 레벨은 총 3단계 중 해당 유저의 레벨에 맞춰 뽑아줘. 질문만 출력해주면 돼";
+
 	public static final String QUESTION_PROMPT =
-			"백엔드 개발자 취업 준비에 필요한 기술면접 질문을 5개 뽑아두고 \"한 문제씩만\" 출력해줘. 매 실행마다 다양한 문제들을 출력해주고 문제 레벨은 총 3단계 중 해당 유저의 레벨에 맞춰 뽑아줘. 질문만 출력해주면 돼";
+			"백엔드 개발자 취업 준비에 필요한 기술면접 질문을 5개를 출력해줘. 문제 레벨은 총 3단계 중 해당 유저의 레벨에 맞춰 뽑아줘. 형식은 질문마다 대괄호에 담아서";
 
 	public static final String ANSWER_PROMPT = "너가 냈던 기술면접 질문 5개에 대한 모범 답안만 알려줘";
 	public static final String FEEDBACK_PROMPT = "사용자로부터 받은 답변을 보고 면접관의 입장에서 어떤지 100점 만점에 몇 점인지 평가와 피드백 해줘. 다른 문장 출력할 필요 없어.";


### PR DESCRIPTION
## 💡 이슈
resolve #38 

## 🤩 개요
면접 질문 리스트 받아오기, 클라이언트에게 질문 하나씩 전송

## 🧑‍💻 작업 사항
버그 수정 및 전체적인 코드 리팩토링
면접 질문 리스트 받아와서 정규표현식으로 분리하고 db에 저장
세션에 독립적으로 db에서 질문 가져오기
개별 세션에서 테스트 진행

## 📖 참고 사항
공유할 내용, 레퍼런스, 추가로 발생할 것으로 예상되는 이슈, 스크린샷 등을 넣어 주세요.

## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
