### PR TITLE
Feat: 모의면접 리스트, 상세페이지 기능 및 임시 화면 구현

### DIFF
--- a/src/main/java/com/est/jobshin/domain/interview/domain/Interview.java
+++ b/src/main/java/com/est/jobshin/domain/interview/domain/Interview.java
@@ -29,6 +29,7 @@ public class Interview {
 	private String title;
 
 //	@NotNull
+	@Enumerated(EnumType.STRING)
 	private Mode mode;
 
 //	@NotNull

--- a/src/main/java/com/est/jobshin/domain/interview/dto/PracticeInterviewHistorySummaryResponse.java
+++ b/src/main/java/com/est/jobshin/domain/interview/dto/PracticeInterviewHistorySummaryResponse.java
@@ -1,6 +1,7 @@
 package com.est.jobshin.domain.interview.dto;
 
 import com.est.jobshin.domain.interview.domain.Interview;
+import com.est.jobshin.domain.interviewDetail.domain.InterviewDetail;
 import java.time.LocalDateTime;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -20,17 +21,18 @@ import lombok.Setter;
 @NoArgsConstructor
 public class PracticeInterviewHistorySummaryResponse {
 
-    private Long id; // 인터뷰 id
-    private String nickname; // 인터뷰한 사용자
-    private String title; // 인터뷰 제목
-    private LocalDateTime createdAt; // 인터뷰 생성 일시
+    private Long id;        // Interview의 id
+    private LocalDateTime createdAt; // Interview의 createAt
+    private Long score;              // InterviewDetail의 score
+    private String category;         // InterviewDetail의 category
 
-    public static PracticeInterviewHistorySummaryResponse toDto(Interview interview) {
+    public static PracticeInterviewHistorySummaryResponse toDto(Interview interview, InterviewDetail interviewDetail,
+            Long totalScore) {
         return PracticeInterviewHistorySummaryResponse.builder()
                 .id(interview.getId())
-                .title(interview.getTitle())
-                .nickname(interview.getUser().getNickname())
                 .createdAt(interview.getCreateAt())
+                .score(totalScore)
+                .category(interviewDetail.getCategory().toString())
                 .build();
     }
 }

--- a/src/main/java/com/est/jobshin/domain/interview/repository/InterviewRepository.java
+++ b/src/main/java/com/est/jobshin/domain/interview/repository/InterviewRepository.java
@@ -1,6 +1,8 @@
 package com.est.jobshin.domain.interview.repository;
 
 import com.est.jobshin.domain.interview.domain.Interview;
+import com.est.jobshin.domain.interview.dto.PracticeInterviewHistorySummaryResponse;
+import com.est.jobshin.domain.interviewDetail.util.Mode;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -11,7 +13,7 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface InterviewRepository extends JpaRepository<Interview, Long> {
 
-    @Query("SELECT i FROM Interview i WHERE (i.mode = com.est.jobshin.domain.interviewDetail.util.Mode.PRACTICE) AND i.user.id = :userId")
-    Page<Interview> findInterviewsWithPracticeModeByUser(@Param("userId") Long userId,
-            Pageable pageable);
+    @Query("SELECT i FROM Interview i JOIN FETCH i.interviewDetails d WHERE i.mode = :mode  AND i.user.id = :userId")
+    Page<Interview> findInterviewsWithPracticeModeByUser(@Param("userId") Long userId
+            , @Param("mode") Mode mode, Pageable pageable);
 }

--- a/src/main/java/com/est/jobshin/domain/interviewDetail/dto/InterviewDetailsResponse.java
+++ b/src/main/java/com/est/jobshin/domain/interviewDetail/dto/InterviewDetailsResponse.java
@@ -1,0 +1,35 @@
+package com.est.jobshin.domain.interviewDetail.dto;
+
+import com.est.jobshin.domain.interview.domain.Interview;
+import com.est.jobshin.domain.interviewDetail.domain.InterviewDetail;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.Getter;
+
+@Getter
+@Setter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class InterviewDetailsResponse {
+    private Long id;
+    private LocalDateTime createdAt;
+    private String title;
+    private List<InterviewDetailDto2> details;
+
+    public static InterviewDetailsResponse toDto(Interview interview, List<InterviewDetail> details) {
+        return InterviewDetailsResponse.builder()
+                .id(interview.getId())
+                .createdAt(interview.getCreateAt())
+                .title(interview.getTitle())
+                .details(details.stream()
+                        .map(detail -> InterviewDetailDto2.from(detail))
+                        .collect(Collectors.toList()))
+                .build();
+    }
+}

--- a/src/main/java/com/est/jobshin/domain/user/controller/UserController.java
+++ b/src/main/java/com/est/jobshin/domain/user/controller/UserController.java
@@ -1,6 +1,8 @@
 package com.est.jobshin.domain.user.controller;
 
 import com.est.jobshin.domain.interview.dto.PracticeInterviewHistorySummaryResponse;
+import com.est.jobshin.domain.interviewDetail.dto.InterviewDetailsResponse;
+import com.est.jobshin.domain.interviewDetail.util.Mode;
 import com.est.jobshin.domain.user.dto.CreateUserRequest;
 import com.est.jobshin.domain.user.dto.UpdateUserRequest;
 import com.est.jobshin.domain.user.dto.UserResponse;
@@ -84,9 +86,10 @@ public class UserController {
     }
 
     // 유저별 인터뷰(연습모드) 이력 리스트
-    @GetMapping("/views/users/interviews/practice")
+    @GetMapping("/views/interviews/practice")
     public String listInterviews(@RequestParam("page") Optional<Integer> page,
             @RequestParam("size") Optional<Integer> size,
+            @RequestParam(value = "mode", defaultValue = "PRACTICE") Mode mode,
             @AuthenticationPrincipal CustomUserDetails userDetails,
             Model model) {
 
@@ -103,8 +106,9 @@ public class UserController {
         Long userId = userDetails.getUserId();
 
         // 페이지네이션된 인터뷰 목록 가져오기
-        Page<PracticeInterviewHistorySummaryResponse> interviewSummaryList = userService.getPaginatedPracticeInterviews(
-                PageRequest.of(currentPage - 1, pageSize), userId);
+        Page<PracticeInterviewHistorySummaryResponse> interviewSummaryList =
+                userService.getPaginatedPracticeInterviews(
+                        PageRequest.of(currentPage - 1, pageSize), userId, mode);
 
         model.addAttribute("interviewSummaryList", interviewSummaryList);
 
@@ -119,6 +123,18 @@ public class UserController {
         }
 
         return "user/practice_interview_list";
+    }
+
+    // 연습모드 상세 정보 조회
+    @GetMapping("/views/interviews/practice/{id}")
+    public String viewInterviewDetails(@PathVariable("id") Long interviewId, Model model) {
+        // 인터뷰 상세 데이터를 가져오는 서비스 메서드 호출
+        InterviewDetailsResponse interviewDetails = userService.getInterviewDetailsById(interviewId);
+
+        // 모델에 인터뷰 상세 데이터 추가
+        model.addAttribute("interviewDetails", interviewDetails);
+
+        return "user/practice_interview_detail";
     }
 
     // 회원가입 요청

--- a/src/main/java/com/est/jobshin/domain/user/service/UserService.java
+++ b/src/main/java/com/est/jobshin/domain/user/service/UserService.java
@@ -3,13 +3,17 @@ package com.est.jobshin.domain.user.service;
 import com.est.jobshin.domain.interview.domain.Interview;
 import com.est.jobshin.domain.interview.dto.PracticeInterviewHistorySummaryResponse;
 import com.est.jobshin.domain.interview.repository.InterviewRepository;
+import com.est.jobshin.domain.interviewDetail.domain.InterviewDetail;
+import com.est.jobshin.domain.interviewDetail.dto.InterviewDetailsResponse;
+import com.est.jobshin.domain.interviewDetail.repository.InterviewDetailRepository;
+import com.est.jobshin.domain.interviewDetail.util.Mode;
 import com.est.jobshin.domain.user.domain.User;
 import com.est.jobshin.domain.user.dto.CreateUserRequest;
 import com.est.jobshin.domain.user.dto.UpdateUserRequest;
 import com.est.jobshin.domain.user.dto.UserResponse;
 import com.est.jobshin.domain.user.repository.UserRepository;
 
-import com.est.jobshin.global.security.model.CustomUserDetails;
+import jakarta.persistence.EntityNotFoundException;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -29,6 +33,7 @@ public class UserService {
 
     private final UserRepository userRepository;
     private final InterviewRepository interviewRepository;
+    private final InterviewDetailRepository interviewDetailRepository;
 
     // 회원 가입 메서드
     @Transactional
@@ -74,22 +79,44 @@ public class UserService {
         userRepository.delete(user);
     }
 
-    // 마이페이지
-    // 모의면접(연습모드) 리스트 페이지네이션
+    // 마이 페이지
+    // 모의 면접 리스트 페이징 처리
     @Transactional(readOnly = true)
     public Page<PracticeInterviewHistorySummaryResponse> getPaginatedPracticeInterviews(
-            Pageable pageable, Long userId) {
+            Pageable pageable, Long userId, Mode mode) {
 
-        // 데이터베이스에서 페이지네이션된 인터뷰 목록을 가져옴
+        // 인터뷰 목록을 페이지네이션으로 가져옴
         Page<Interview> interviewsPage = interviewRepository.findInterviewsWithPracticeModeByUser(
-                userId, pageable);
+                userId, mode, pageable);
 
         // 인터뷰 목록을 DTO로 변환
         List<PracticeInterviewHistorySummaryResponse> practiceInterviewList = interviewsPage.stream()
-                .map(PracticeInterviewHistorySummaryResponse::toDto)
+                .map(interview -> {
+                    // 인터뷰의 모든 디테일에서 점수를 합산
+                    Long totalScore = interview.getInterviewDetails().stream()
+                            .mapToLong(InterviewDetail::getScore)
+                            .sum();
+
+                    // 인터뷰의 첫 번째 디테일로 카테고리 설정
+                    InterviewDetail firstDetail = interview.getInterviewDetails().stream()
+                            .findFirst().orElse(null);
+
+                    return PracticeInterviewHistorySummaryResponse.toDto(interview, firstDetail,
+                            totalScore / 5);
+                })
                 .collect(Collectors.toList());
 
         // DTO 리스트를 페이지네이션된 결과로 반환
         return new PageImpl<>(practiceInterviewList, pageable, interviewsPage.getTotalElements());
+    }
+
+    // 모의 면접 상세 보기
+    @Transactional(readOnly = true)
+    public InterviewDetailsResponse getInterviewDetailsById(Long interviewId){
+        Interview interview = interviewRepository.findById(interviewId)
+                .orElseThrow(() -> new EntityNotFoundException("인터뷰를 찾을 수 없습니다."));
+        List<InterviewDetail> details = interviewDetailRepository.findByInterviewId(interviewId);
+
+        return InterviewDetailsResponse.toDto(interview, details);
     }
 }

--- a/src/main/resources/templates/user/practice_interview_detail.html
+++ b/src/main/resources/templates/user/practice_interview_detail.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+    <title>Interview Details</title>
+</head>
+<body>
+<h1>인터뷰 상세 페이지</h1>
+<table>
+    <tr>
+        <th>인터뷰 번호</th>
+        <th>인터뷰 생성일시</th>
+        <th>인터뷰 제목</th>
+    </tr>
+    <tr>
+        <td th:text="${interviewDetails.id}"></td>
+        <td th:text="${interviewDetails.createdAt}"></td>
+        <td th:text="${interviewDetails.title}"></td>
+    </tr>
+</table>
+
+<h2>인터뷰 상세</h2>
+<table>
+    <tr>
+        <th>Question</th>
+        <th>Answer</th>
+        <th>Score</th>
+    </tr>
+    <tr th:each="detail : ${interviewDetails.details}">
+        <td th:text="${detail.question}"></td>
+        <td th:text="${detail.answer}"></td>
+    </tr>
+</table>
+<a href="#" th:href="@{/views/interviews/practice}">Back to List</a>
+</body>
+</html>

--- a/src/main/resources/templates/user/practice_interview_list.html
+++ b/src/main/resources/templates/user/practice_interview_list.html
@@ -1,83 +1,106 @@
 <!DOCTYPE html>
 <html xmlns:th="http://www.thymeleaf.org">
 <head>
+    <link rel="stylesheet" href="/css/main.css">
     <link rel="stylesheet" href="/css/header.css">
+    <link rel="stylesheet" href="/css/sidebar.css">
+    <link rel="stylesheet" href="/css/table.css">
     <title>Practice Interview List</title>
 </head>
 <body>
 <div th:replace="~{layout/header.html :: header}"></div>
-
-<table id="interview-table">
-    <thead>
-    <tr>
-        <th>Id</th>
-        <th>Title</th>
-        <th>NickName</th>
-        <th>Date</th>
-    </tr>
-    </thead>
-    <tbody>
-    <!-- 인터뷰 데이터 렌더링 -->
-    <tr th:each=" interview : ${interviewSummaryList}">
-        <td th:text="${interview.id}"></td>
-        <td th:text="${interview.title}">제목</td>
-        <td th:text="${interview.nickname}">사용자 이름</td>
-        <td th:text="${interview.createdAt}">날짜 및 시간</td>
-    </tr>
-    </tbody>
-</table>
-
-<!-- 페이지네이션 버튼 -->
-<nav aria-label="Page navigation">
-    <!--표에 사용될 변수값 초기화 -->
-    <ul class="pagination justify-content-center" th:with="start=${T(java.lang.Math).floor(interviewSummaryList.number / 10) * 10 + 1}, last=(${start + 9 < interviewSummaryList.totalPages ? start + 9 : interviewSummaryList.totalPages})">
-        <th:block th:with="
-            firstAddr=@{/views/users/interviews/practice(page=1)},
-            prevAddr=@{/views/users/interviews/practice(page=${interviewSummaryList.number})},
-            nextAddr=@{/views/users/interviews/practice(page=${interviewSummaryList.number + 2})},
-            lastAddr=@{/views/users/interviews/practice(page=${interviewSummaryList.totalPages})}">
-            <li class="page-item">
-                <a class="page-link" th:href="${firstAddr}" aria-label="First">
-                    <span aria-hidden="true"> << </span>
-                </a>
-            </li>
-            <!-- 이전 페이지로 가기 버튼 -->
-            <li class="page-item" th:class="${interviewSummaryList.first} ? 'disabled'">
-                <a class="page-link" th:href="${interviewSummaryList.first} ? '#' :${prevAddr}"
-                   aria-label="Previous">
-                    <span aria-hidden="true">&lt;</span>
-                </a>
-            </li>
-            <!--1,2,3,4,.. 등 페이지-->
-            <li class="page-item" th:each="page: ${#numbers.sequence(start, last)}"
-                th:class="${page == interviewSummaryList.number + 1} ? 'active'">
-                <a class="page-link" th:text="${page}" th:href="@{/views/users/interviews/practice(page=${page})}"></a>
-            </li>
-            <!--다음 페이지로 -->
-            <li class="page-item" th:class="${interviewSummaryList.last} ? 'disabled'">
-                <a class="page-link" th:href="${interviewSummaryList.last} ? '#' : ${nextAddr}"
-                   aria-label="Next">
-                    <span aria-hidden="true">&gt;</span>
-                </a>
-            </li>
-            <!--맨 마지막 페이지로 이동 -->
-            <li class="page-item">
-                <a class="page-link" th:href="${lastAddr}" aria-label="Last">
-                    <span aria-hidden="true"> >> </span>
-                </a>
-            </li>
-        </th:block>
-    </ul>
-</nav>
-<!--<div id="pagination">
-    <button th:disabled="${currentPage == 0}"
-            th:href="@{/views/users/interviews/list/practice(page=${currentPage - 1}, size=${size})}">
-        Previous
-    </button>
-    <button th:disabled="${currentPage >= totalPages - 1}"
-            th:href="@{/views/users/interviews/list/practice(page=${currentPage + 1}, size=${size})}">
-        Next
-    </button>
-</div>-->
+<main class="main">
+    <div class="container">
+        <!-- Sidebar Sec-->
+        <aside class="sidebar">
+            <div class="sidebar-section">
+                <h3>마이 페이지</h3>
+                <ul class="sidebar-menu">
+                    <li><a href="/views/users/edit">회원 정보 수정</a></li>
+                    <li><a href="/views/interviews/history">면접 이력</a></li>
+                    <li><a href="/views/users/withdrawal">회원 탈퇴</a></li>
+                </ul>
+            </div>
+            <div class="sidebar-section">
+                <h3>면접 기록</h3>
+                <ul class="sidebar-menu">
+                    <li><a href="/views/interviews/practice">연습 모드 이력</a></li>
+                    <li><a href="/views/interviews/real">실전 모드 이력</a></li>
+                    <li><a href="/views/interviews/scheduled">Today's Scheduled</a></li>
+                </ul>
+            </div>
+        </aside>
+        <section class="content">
+            <table class="table">
+                <thead class="table-light">
+                <tr>
+                    <th>번호</th>
+                    <th>생성 일시</th>
+                    <th>점수</th>
+                    <th>카테고리</th>
+                </tr>
+                </thead>
+                <tbody align="center">
+                <!-- 인터뷰 데이터 렌더링 -->
+                <tr th:each=" interview : ${interviewSummaryList}">
+                    <td>
+                        <a th:href="@{/views/interviews/practice/{id}(id = ${interview.id})}" th:text="${interview.id}">번호</a>
+                    </td>
+                    <td>
+                        <a th:href="@{/views/interviews/practice/{id}(id = ${interview.id})}" th:text="${interview.createdAt}">생성 일시</a></td>
+                    <td th:text="${interview.score}">점수</td>
+                    <td th:text="${interview.category}">카테고리</td>
+                </tr>
+                </tbody>
+            </table>
+        </section>
+        <!-- 페이지네이션 버튼 -->
+        <nav aria-label="Page navigation">
+            <!--표에 사용될 변수값 초기화 -->
+            <ul class="pagination justify-content-center"
+                th:with="start=${T(java.lang.Math).floor(interviewSummaryList.number / 10) * 10 + 1}, last=(${start + 9 < interviewSummaryList.totalPages ? start + 9 : interviewSummaryList.totalPages})">
+                <th:block th:with="
+            firstAddr=@{/views/interviews/practice(page=1)},
+            prevAddr=@{/views/interviews/practice(page=${interviewSummaryList.number})},
+            nextAddr=@{/views/interviews/practice(page=${interviewSummaryList.number + 2})},
+            lastAddr=@{/views/interviews/practice(page=${interviewSummaryList.totalPages})}">
+                    <li class="page-item">
+                        <a class="page-link" th:href="${firstAddr}" aria-label="First">
+                            <span aria-hidden="true"> << </span>
+                        </a>
+                    </li>
+                    <!-- 이전 페이지로 가기 버튼 -->
+                    <li class="page-item" th:class="${interviewSummaryList.first} ? 'disabled'">
+                        <a class="page-link"
+                           th:href="${interviewSummaryList.first} ? '#' :${prevAddr}"
+                           aria-label="Previous">
+                            <span aria-hidden="true">&lt;</span>
+                        </a>
+                    </li>
+                    <!--1,2,3,4,.. 등 페이지-->
+                    <li class="page-item" th:each="page: ${#numbers.sequence(start, last)}"
+                        th:class="${page == interviewSummaryList.number + 1} ? 'active'">
+                        <a class="page-link" th:text="${page}"
+                           th:href="@{/views/interviews/practice(page=${page})}"></a>
+                    </li>
+                    <!--다음 페이지로 -->
+                    <li class="page-item" th:class="${interviewSummaryList.last} ? 'disabled'">
+                        <a class="page-link"
+                           th:href="${interviewSummaryList.last} ? '#' : ${nextAddr}"
+                           aria-label="Next">
+                            <span aria-hidden="true">&gt;</span>
+                        </a>
+                    </li>
+                    <!--맨 마지막 페이지로 이동 -->
+                    <li class="page-item">
+                        <a class="page-link" th:href="${lastAddr}" aria-label="Last">
+                            <span aria-hidden="true"> >> </span>
+                        </a>
+                    </li>
+                </th:block>
+            </ul>
+        </nav>
+    </div>
+</main>
 </body>
 </html>


### PR DESCRIPTION
## 💡 이슈
resolve #70 

## 🤩 개요
모의면접 리스트, 상세페이지 기능 및 임시 화면 구현

## 🧑‍💻 작업 사항
- 모의 면접 리스트 페이징 처리 기능 및 화면구현
- 상세페이지 화면 구현(임시)


## 📖 참고 사항
- 인터뷰 연습모드 리스트 화면
  <img width="1055" alt="image" src="https://github.com/user-attachments/assets/a4d9d481-b09a-469a-9873-9297cf8ea447">
- 인터뷰 연습모드 상세페이지
  <img width="774" alt="image" src="https://github.com/user-attachments/assets/31b13a22-64f3-4aa9-b74c-b33d2a5a3ec6">

## ✅ Check List
- [ ] 코드가 정상적으로 컴파일되나요?
- [ ] 테스트 코드를 통과했나요?
- [ ] merge할 브랜치의 위치를 확인했나요?
- [ ] Label을 지정했나요?
