### PR TITLE
fix: score가 null일 때 해당 점수를 제외한 평균값 계산 후 0으로 반환

### DIFF
--- a/src/main/java/com/est/jobshin/domain/user/dto/MyPageInterviewDetailDto.java
+++ b/src/main/java/com/est/jobshin/domain/user/dto/MyPageInterviewDetailDto.java
@@ -33,7 +33,7 @@ public class MyPageInterviewDetailDto {
 			.answer(interviewDetail.getAnswer())
 			.category(interviewDetail.getCategory())
 			.mode(interviewDetail.getMode())
-			.score(interviewDetail.getScore())
+			.score(interviewDetail.getScore() != null ? interviewDetail.getScore() : 0L)
 			.exampleAnswer(interviewDetail.getExampleAnswer())
 			.createdAt(interviewDetail.getCreatedAt())
 			.build();


### PR DESCRIPTION
## 💡 이슈
resolve #104 

## 🤩 개요
score가 null일 때 해당 점수를 제외한 평균값 계산 후 0으로 반환 하여 NullPointExecption이 생기는 문제 해결

## 🧑‍💻 작업 사항
MyPageInterviewDetailDto 클래스 수정

## 📖 참고 사항
공유할 내용, 레퍼런스, 추가로 발생할 것으로 예상되는 이슈, 스크린샷 등을 넣어 주세요.

## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
