### PR TITLE
fix: 회원정보 수정 테스트 시 UserResponse가 null로 반환되는 문제 해결 및 코드 정렬

### DIFF
--- a/src/main/java/com/est/jobshin/domain/user/service/UserService.java
+++ b/src/main/java/com/est/jobshin/domain/user/service/UserService.java
@@ -4,7 +4,6 @@ import com.est.jobshin.domain.interview.domain.Interview;
 import com.est.jobshin.domain.interview.dto.InterviewHistorySummaryResponse;
 import com.est.jobshin.domain.interview.repository.InterviewRepository;
 import com.est.jobshin.domain.interviewDetail.domain.InterviewDetail;
-import com.est.jobshin.domain.interviewDetail.repository.InterviewDetailRepository;
 import com.est.jobshin.domain.interviewDetail.util.Mode;
 import com.est.jobshin.domain.user.domain.User;
 import com.est.jobshin.domain.user.dto.CreateUserRequest;
@@ -30,7 +29,6 @@ public class UserService {
 
     private final UserRepository userRepository;
     private final InterviewRepository interviewRepository;
-    private final InterviewDetailRepository interviewDetailRepository;
 
     // 회원 가입 메서드
     @Transactional
@@ -79,10 +77,12 @@ public class UserService {
     // 마이 페이지
     // 모의 면접 리스트 페이징 처리
     @Transactional(readOnly = true)
-    public Page<InterviewHistorySummaryResponse> getPaginatedInterviews(Pageable pageable, Long userId, Mode mode) {
+    public Page<InterviewHistorySummaryResponse> getPaginatedInterviews(Pageable pageable,
+            Long userId, Mode mode) {
 
         // 인터뷰 목록을 페이지네이션으로 가져옴
-        Page<Interview> interviewsPage = interviewRepository.findInterviewsWithPracticeModeByUser(userId, mode, pageable);
+        Page<Interview> interviewsPage = interviewRepository.findInterviewsWithPracticeModeByUser(
+                userId, mode, pageable);
 
         // 인터뷰 목록을 DTO로 변환
         List<InterviewHistorySummaryResponse> practiceInterviewList = interviewsPage.stream()
@@ -96,7 +96,8 @@ public class UserService {
                     InterviewDetail firstDetail = interview.getInterviewDetails().stream()
                             .findFirst().orElse(null);
 
-                    return InterviewHistorySummaryResponse.toDto(interview, firstDetail, totalScore / 5);
+                    return InterviewHistorySummaryResponse.toDto(interview, firstDetail,
+                            totalScore / 5);
 
                 })
                 .collect(Collectors.toList());
@@ -111,19 +112,21 @@ public class UserService {
     public MyPageInterviewWithDetailsDto getInterviewDetail(Long id) {
 
         Interview interview = interviewRepository.findById(id)
-            .orElseThrow(() -> new EntityNotFoundException("Interview not found with id " + id));
+                .orElseThrow(
+                        () -> new EntityNotFoundException("Interview not found with id " + id));
 
         // 점수 평균 계산 (정수형)
         int averageScore = (int) Math.round(
-            interview.getInterviewDetails().stream()
-                .filter(detail -> detail.getScore() != null)  // 점수가 null이 아닌 경우에만 고려
-                .mapToLong(InterviewDetail::getScore)
-                .average()
-                .orElse(0.0)
+                interview.getInterviewDetails().stream()
+                        .filter(detail -> detail.getScore() != null)  // 점수가 null이 아닌 경우에만 고려
+                        .mapToLong(InterviewDetail::getScore)
+                        .average()
+                        .orElse(0.0)
         );
 
         // DTO로 변환
-        MyPageInterviewWithDetailsDto myPageInterviewWithDetailsDto = MyPageInterviewWithDetailsDto.fromInterview(interview);
+        MyPageInterviewWithDetailsDto myPageInterviewWithDetailsDto = MyPageInterviewWithDetailsDto.fromInterview(
+                interview);
         myPageInterviewWithDetailsDto.setAverageScore(averageScore);
 
         return myPageInterviewWithDetailsDto;


### PR DESCRIPTION
## 💡 이슈
resolve #132 

## 🤩 개요
회원정보 수정 테스트 시 UserResponse가 null로 반환되는 문제 해결 및 코드 정렬

## 🧑‍💻 작업 사항
- UserController
  - 회원 정보 수정 메서드에서 @AuthenticationPrincipal 어노테이션 삭제 후 CustomUserDetails에서 회원 정보를 가져오는 방식으로 변경
- UserService
  - 사용하지 않는 필드 삭제

## 📖 참고 사항
공유할 내용, 레퍼런스, 추가로 발생할 것으로 예상되는 이슈, 스크린샷 등을 넣어 주세요.

## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
