### PR TITLE
Fix: 연습 모드/실전 모드 이력 페이지네이션 계산 오류

### DIFF
--- a/src/main/java/com/est/jobshin/domain/interview/repository/InterviewRepository.java
+++ b/src/main/java/com/est/jobshin/domain/interview/repository/InterviewRepository.java
@@ -3,6 +3,7 @@ package com.est.jobshin.domain.interview.repository;
 import com.est.jobshin.domain.interview.domain.Interview;
 import com.est.jobshin.domain.interviewDetail.util.Mode;
 import com.est.jobshin.domain.user.util.Level;
+import java.util.List;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -17,8 +18,8 @@ public interface InterviewRepository extends JpaRepository<Interview, Long> {
             Pageable pageable, Mode mode);
 
     @Query("SELECT i FROM Interview i JOIN FETCH i.interviewDetails d WHERE i.mode = :mode  AND i.user.id = :userId ORDER BY i.complete ASC ")
-    Page<Interview> findInterviewsWithPracticeModeByUser(@Param("userId") Long userId
-            , @Param("mode") Mode mode, Pageable pageable);
+    List<Interview> findInterviewsWithPracticeModeByUser(@Param("userId") Long userId
+            , @Param("mode") Mode mode);
 
 
 }

--- a/src/main/java/com/est/jobshin/domain/user/service/UserService.java
+++ b/src/main/java/com/est/jobshin/domain/user/service/UserService.java
@@ -79,8 +79,8 @@ public class UserService {
             Long userId, Mode mode) {
 
         // 인터뷰 목록을 페이지네이션으로 가져옴
-        Page<Interview> interviewsPage = interviewRepository.findInterviewsWithPracticeModeByUser(
-                userId, mode, pageable);
+        List<Interview> interviewsPage = interviewRepository.findInterviewsWithPracticeModeByUser(
+                userId, mode);
 
         // 인터뷰 목록을 DTO로 변환
         List<InterviewHistorySummaryResponse> practiceInterviewList = interviewsPage.stream()
@@ -100,8 +100,16 @@ public class UserService {
                 })
                 .collect(Collectors.toList());
 
+        // 페이지네이션 처리 (practiceInterviewList 기준)
+        int start = (int) pageable.getOffset();
+        int end = Math.min((start + pageable.getPageSize()), practiceInterviewList.size());
+
+        // 페이지 내 범위에 해당하는 리스트 추출
+        List<InterviewHistorySummaryResponse> paginatedList = practiceInterviewList.subList(start, end);
+
         // DTO 리스트를 페이지네이션된 결과로 반환
-        return new PageImpl<>(practiceInterviewList, pageable, interviewsPage.getTotalElements());
+        return new PageImpl<>(paginatedList, pageable, practiceInterviewList.size());
+
     }
 
 

--- a/src/main/resources/templates/user/practice_interview_list.html
+++ b/src/main/resources/templates/user/practice_interview_list.html
@@ -73,7 +73,7 @@
                     th:with="start=${T(java.lang.Math).floor((interviewSummaryList.number + 1) / 10) * 10 + 1}, last=(${start + 9 < interviewSummaryList.totalPages ? start + 9 : interviewSummaryList.totalPages})">
                     <th:block th:with="
             firstAddr=@{/views/users/interviews/practice(page=1)},
-            prevAddr=@{/views/users/interviews/practice(page=${interviewSummaryList.number + 1})},
+            prevAddr=@{/views/users/interviews/practice(page=${interviewSummaryList.number})},
             nextAddr=@{/views/users/interviews/practice(page=${interviewSummaryList.number + 2})},
             lastAddr=@{/views/users/interviews/practice(page=${interviewSummaryList.totalPages})}">
                         <li class="page-item">


### PR DESCRIPTION
## 💡 이슈
resolve #171 

## 🤩 개요
연습 모드/실전 모드 이력 페이지네이션 계산 오류

## 🧑‍💻 작업 사항
InterviewRepository 에서 불필요한 파라미터 값 제거, 반환 타입 page -> list로 변경
UserService 페이징 처리와 관련된 계산 로직 추가
뷰 링크 변경

## 📖 참고 사항

## ✅ Check List
- [ ] 코드가 정상적으로 컴파일되나요?
- [ ] 테스트 코드를 통과했나요?
- [ ] merge할 브랜치의 위치를 확인했나요?
- [ ] Label을 지정했나요?
