### PR TITLE
Fix: 면접 이어하기시 이미 푼 문제도 포함되는 부분 수정

### DIFF
--- a/src/main/java/com/est/jobshin/domain/interviewDetail/domain/InterviewDetail.java
+++ b/src/main/java/com/est/jobshin/domain/interviewDetail/domain/InterviewDetail.java
@@ -81,6 +81,13 @@ public class InterviewDetail {
     }
 
     /**
+     * 답변 등록 상태로 변경
+     */
+    public void registerAnswerComplete() {
+        this.complete = true;
+    }
+
+    /**
      * 전달 받은 피드백을 저장, 해당 문제를 완료처리
      * @param exampleAnswer 앨런으로부터 전달 받은 예시 답변
      * @param score 앨런으로부터 전달 받은 점수

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -26,7 +26,7 @@ spring:
   jpa:
     hibernate:
       ddl-auto: none
-    show-sql: true
+#    show-sql: true
     properties:
       hibernate:
         dialect: org.hibernate.dialect.MySQL8Dialect


### PR DESCRIPTION
## 💡 이슈
resolve #192 

## 🤩 개요
면접 이어하기시 버그 수정

## 🧑‍💻 작업 사항
InterviewService에서 작업을 큐에 등록하는 시점에 푼 문제로 체크 되도록 수정
새 면접 시작과 면접 이어하기 두곳에서 동일하게 사용하던 세션데이터 초기화 메서드를 각각 따로 분리

## 📖 참고 사항
공유할 내용, 레퍼런스, 추가로 발생할 것으로 예상되는 이슈, 스크린샷 등을 넣어 주세요.

## ✅ Check List
- [ ] 코드가 정상적으로 컴파일되나요?
- [ ] 테스트 코드를 통과했나요?
- [ ] merge할 브랜치의 위치를 확인했나요?
- [ ] Label을 지정했나요?
